### PR TITLE
WCM-357 Missing user segment can exist in the actual group as well

### DIFF
--- a/content-targeting-api/src/com/liferay/content/targeting/lar/UserSegmentStagedModelDataHandler.java
+++ b/content-targeting-api/src/com/liferay/content/targeting/lar/UserSegmentStagedModelDataHandler.java
@@ -97,7 +97,13 @@ public class UserSegmentStagedModelDataHandler
 
 		UserSegment existingUserSegment =
 			UserSegmentLocalServiceUtil.fetchUserSegmentByUuidAndGroupId(
-				uuid, portletDataContext.getCompanyGroupId());
+				uuid, portletDataContext.getScopeGroupId());
+
+		if (existingUserSegment == null) {
+			existingUserSegment = 
+				UserSegmentLocalServiceUtil.fetchUserSegmentByUuidAndGroupId(
+					uuid, portletDataContext.getCompanyGroupId());
+		}
 
 		Map<Long, Long> userSegmentIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(


### PR DESCRIPTION
Hi experts,

The fix refers to LPS-47857's fix(commit: Missing file entries can exist in the actual group as well) regarding FileEntryStagedModelDataHandler.doImportCompanyStagedModel() in ee-6.2.x.

The issue occurs after the first publish completed, if you create one new Campaign and link to the previous user segment. In this case, when export campaign and it will export related data regarding UserSegments (in CampaignStagedModelDataHandler.doExportStagedModel() {exportUserSegments();}). 

But in exportUserSegments() method portletDataContext.getBooleanParameter(
ContentTargetingPortletDataHandler.NAMESPACE,"user-segments") will be false because we don't add new user segment in the second publishing. So it will add missing Reference.
 
When import Campaign, it will import ReferenceUserSegments, in StagedModelDataHandlerUtil.importReferenceStagedModel(), it will execute if (missing) {} block. 

So we should add the fix logic. Because in this case, it will explain user segment have existed in the actual remote group.

Please help review it,

Thanks,
Hai
