### PR TITLE
[TECHNICAL-SUPPORT] WCM-368 Stopping OSGI bundle for Audience Targeting triggers error

### DIFF
--- a/content-targeting-deploy-extender/src/com/liferay/content/targeting/deploy/hot/extender/internal/activator/HotDeployTrackerComponent.java
+++ b/content-targeting-deploy-extender/src/com/liferay/content/targeting/deploy/hot/extender/internal/activator/HotDeployTrackerComponent.java
@@ -126,9 +126,11 @@ public class HotDeployTrackerComponent {
 
 	@Activate
 	protected void activate(final BundleContext bundleContext) {
+		ServiceTrackerCustomizer servletContextTracker =
+			new ServletContextTrackerCustomizer(bundleContext);
+
 		_serviceTracker = new ServiceTracker<ServletContext, ServletContext>(
-			bundleContext, ServletContext.class,
-			new ServletContextTrackerCustomizer());
+			bundleContext, ServletContext.class, servletContextTracker);
 
 		_serviceTracker.open();
 
@@ -162,6 +164,10 @@ public class HotDeployTrackerComponent {
 
 	private class ServletContextTrackerCustomizer
 		implements ServiceTrackerCustomizer<ServletContext, ServletContext> {
+
+		public ServletContextTrackerCustomizer(BundleContext context) {
+			_context = context;
+		}
 
 		@Override
 		public ServletContext addingService(
@@ -213,6 +219,8 @@ public class HotDeployTrackerComponent {
 
 			bundleContext.ungetService(serviceReference);
 		}
+
+		BundleContext _context;
 	}
 
 }

--- a/content-targeting-deploy-extender/src/com/liferay/content/targeting/deploy/hot/extender/internal/activator/HotDeployTrackerComponent.java
+++ b/content-targeting-deploy-extender/src/com/liferay/content/targeting/deploy/hot/extender/internal/activator/HotDeployTrackerComponent.java
@@ -181,7 +181,7 @@ public class HotDeployTrackerComponent {
 
 			BundleContext bundleContext = bundle.getBundleContext();
 
-			ServletContext servletContext = bundleContext.getService(
+			ServletContext servletContext = _context.getService(
 				serviceReference);
 
 			_osgiDeployContexts.putIfAbsent(
@@ -207,15 +207,13 @@ public class HotDeployTrackerComponent {
 
 			Bundle bundle = serviceReference.getBundle();
 
-			BundleContext bundleContext = bundle.getBundleContext();
-
 			HotDeployUtil.fireUndeployEvent(
 				new HotDeployEvent(servletContext, _getClassLoader(bundle))
 			);
 
 			_osgiDeployContexts.remove(servletContext.getServletContextName());
 
-			bundleContext.ungetService(serviceReference);
+			_context.ungetService(serviceReference);
 		}
 
 		BundleContext _context;

--- a/content-targeting-deploy-extender/src/com/liferay/content/targeting/deploy/hot/extender/internal/activator/HotDeployTrackerComponent.java
+++ b/content-targeting-deploy-extender/src/com/liferay/content/targeting/deploy/hot/extender/internal/activator/HotDeployTrackerComponent.java
@@ -191,8 +191,6 @@ public class HotDeployTrackerComponent {
 			HotDeployUtil.fireDeployEvent(
 				new HotDeployEvent(servletContext, _getClassLoader(bundle)));
 
-			bundleContext.ungetService(serviceReference);
-
 			return servletContext;
 		}
 

--- a/content-targeting-deploy-extender/src/com/liferay/content/targeting/deploy/hot/extender/internal/activator/HotDeployTrackerComponent.java
+++ b/content-targeting-deploy-extender/src/com/liferay/content/targeting/deploy/hot/extender/internal/activator/HotDeployTrackerComponent.java
@@ -160,7 +160,6 @@ public class HotDeployTrackerComponent {
 	private MessageBus _messageBus;
 	private ConcurrentHashMap<String, OsgiDeployContext> _osgiDeployContexts =
 		new ConcurrentHashMap<String, OsgiDeployContext>();
-	private ServletContext _portalServletContext;
 	private MessageListener _serviceRegistratorMessageListener =
 		new ServiceRegistratorMessageListener();
 	private ServiceTracker<ServletContext, ServletContext> _serviceTracker;


### PR DESCRIPTION
https://issues.liferay.com/browse/WCM-368

Hi Guys,

Carlos @csierra : can you please check it first? (I couldn't send it to you directly, as you don't have the "develop" branch pushed in your origin)

This is what I wrote first to Norbi in regards to this issue:
According to the official User Guide for AT 6.2, the suggested way to uninstall AT is to delete the "osgi" folder completely and also clear the container's temp-work directories, then, restart the sever.

https://www.liferay.com/documentation/liferay-portal/6.2/user-guide/-/ai/installation-and-uninstallation-liferay-portal-6-2-user-guide-07-en

In addition, the following article refers to the OSGi support in 6.2 as "experimental" and not supported:

https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/developing-osgi-plugins-for-liferay

-----------

Even though you may not want to support it, there is a customer who has been waiting for this for a while, so if you decide to reject this solution, please, help us to come up with a reasonable explanation we can sell to the subscriber.

Thanks a lot,
Tibi

/cc @NorbertKocsis