### PR TITLE
[TECHNICAL-SUPPORT] WCM-416 User Segment with Site Member rule cannot be imported

### DIFF
--- a/rule-site-member/src/com/liferay/content/targeting/rule/site/member/SiteMemberRule.java
+++ b/rule-site-member/src/com/liferay/content/targeting/rule/site/member/SiteMemberRule.java
@@ -90,20 +90,12 @@ public class SiteMemberRule extends BaseRule {
 
 		Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 
-		if (group != null ) {
-			ruleInstance.setTypeSettings(group.getUuid());
-
-			portletDataContext.addReferenceElement(
-				ruleInstance, ruleInstanceElement, group,
-				PortletDataContext.REFERENCE_TYPE_WEAK, true);
-
-			return;
+		if (group == null ) {
+			throw new PortletDataException(
+				getExportImportErrorMessage(
+					userSegment, ruleInstance, Group.class.getName(),
+					String.valueOf(groupId), Constants.EXPORT));
 		}
-
-		throw new PortletDataException(
-			getExportImportErrorMessage(
-				userSegment, ruleInstance, Group.class.getName(),
-				String.valueOf(groupId), Constants.EXPORT));
 	}
 
 	@Override


### PR DESCRIPTION
Hi @epgarcia ,

we don't have StagedModelDataHandler for groups in 62x, therefore the reference validation doesn't work.

I decided to remove the reference, as during the import the **importData** method creates a message if the group doesn't exist, and the import process finishes successfully anyway.

cc @matethurzo

Thanks,
Tamás