### PR TITLE
WCM-1361 Get proper id when HTML Attributes and DOM Properties differ

### DIFF
--- a/analytics-hook/docroot/META-INF/custom_jsps/html/common/themes/bottom-ext.jsp
+++ b/analytics-hook/docroot/META-INF/custom_jsps/html/common/themes/bottom-ext.jsp
@@ -50,7 +50,7 @@
 
 				A.all('form').each(
 					function(item) {
-						var formId = item.attr('id');
+						var formId = item.getAttribute('id');
 
 						if (!defaultFormExcludedIdsRegex.test(formId) && (!formExcludedIdsRegexStr || !new RegExp(formExcludedIdsRegexStr).test(formId))) {
 							trackingForms.push(formId);


### PR DESCRIPTION
Most of the time, HTML Attributes and DOM Properties are the same, but not always. In the case when one of the fields of a select or form tag is set to "id" and you are trying to get "id" via Javascript, the values will be different. For a clearer explanation with code, check out this demo that @tylerwonglr made.
http://codepen.io/ursatechie/pen/EWzrjJ

As described in [WCM-1361](https://issues.liferay.com/browse/WCM-1361), this issue also affects 2.x of Audience Targeting. 