### PR TITLE
WCM-1387 plain content-type for FireFox empty response

### DIFF
--- a/analytics-processor-service/src/com/liferay/content/targeting/analytics/processor/servlet/AnalyticsProcessorServlet.java
+++ b/analytics-processor-service/src/com/liferay/content/targeting/analytics/processor/servlet/AnalyticsProcessorServlet.java
@@ -58,6 +58,11 @@ public class AnalyticsProcessorServlet extends HttpServlet {
 		throws IOException, ServletException {
 
 		try {
+			if (!(response.containsHeader("Content-Length") ||
+					response.containsHeader("Content-Type"))) {
+						response.setContentType("text/plain");
+			}
+
 			processEvents(request, response);
 		}
 		catch (Exception e) {


### PR DESCRIPTION
https://issues.liferay.com/browse/WCM-1387

FireFox attempts to parse a blank response (content-length 0) by default as XML which gives an error.  The fix here is intended to set the default content-type of the response to "text/plain" when the response is blank.